### PR TITLE
Add `python -m` to all `pip install` commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,5 @@ jobs:
       - image: python:3.6
     steps:
       - checkout
-      - run: pip install mlrun
+      - run: python -m pip install mlrun
       - run: mlrun run --handler my_func --param-file params.csv --dump myfunc.py

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
       - image: python:3.6
     steps:
       - checkout
-      - run: pip install mlrun
+      - run: python -m pip install mlrun
       - run: mlrun run --handler my_func --param-file params.csv --dump myfunc.py
 ```
 

--- a/function.yaml
+++ b/function.yaml
@@ -6,5 +6,5 @@ spec:
   entry_points:
     my_func: {}
   build:
-    commands: ['pip install pandas']
+    commands: ['python -m pip install pandas']
   description: 'a demo function'


### PR DESCRIPTION
Added at the suggestion of Yasha and Or to ensure that the installed version matches the active Python version.
I'm also preparing similar updates in the mlrun/mlrun repo.

@yaronha please review and merge.